### PR TITLE
Enables shpool tap for homebrew

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,29 +1,48 @@
 name: Update Homebrew formula
 
-# Triggered manually or via repository_dispatch from shell-pool/shpool.
-# To trigger automatically on release, add a workflow step to shell-pool/shpool
-# that calls the GitHub API to dispatch this workflow with the new version tag.
 on:
+  schedule:
+    - cron: '0 6 * * *'  # daily at 6am UTC
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version tag (e.g. v0.9.5)'
-        required: true
-  repository_dispatch:
-    types: [new-release]
+        description: 'Release version tag (e.g. v0.9.5) — leave blank to fetch latest'
+        required: false
 
 jobs:
   update-formula:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
-      - name: Update formula version and SHA256
+      - name: Resolve version
+        id: version
         run: |
-          VERSION="${{ github.event.inputs.version || github.event.client_payload.version }}"
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION=$(curl -s https://api.github.com/repos/shell-pool/shpool/releases/latest | jq -r '.tag_name')
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if update is needed
+        id: check
+        run: |
+          CURRENT=$(grep -oP 'refs/tags/\K[^"]+' Formula/shpool.rb | head -1)
+          echo "current=${CURRENT}"
+          echo "latest=${{ steps.version.outputs.version }}"
+          if [ "$CURRENT" = "${{ steps.version.outputs.version }}" ]; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update formula version and SHA256
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
           URL="https://github.com/shell-pool/shpool/archive/refs/tags/${VERSION}.tar.gz"
           SHA256=$(curl -sL "$URL" | shasum -a 256 | awk '{print $1}')
 
@@ -31,8 +50,9 @@ jobs:
           sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" Formula/shpool.rb
 
       - name: Commit and push
+        if: steps.check.outputs.needed == 'true'
         run: |
-          VERSION="${{ github.event.inputs.version || github.event.client_payload.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -30,22 +30,12 @@ jobs:
           sed -i "s|url \".*\"|url \"${URL}\"|" Formula/shpool.rb
           sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" Formula/shpool.rb
 
-      - name: Open PR
+      - name: Commit and push
         run: |
           VERSION="${{ github.event.inputs.version || github.event.client_payload.version }}"
-          BRANCH="update-formula-${VERSION}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
           git add Formula/shpool.rb
           git commit -m "Update formula to ${VERSION}"
-          git push origin "$BRANCH"
-
-          gh pr create \
-            --title "Update formula to ${VERSION}" \
-            --body "Automated update of \`Formula/shpool.rb\` for release ${VERSION}." \
-            --base master \
-            --head "$BRANCH"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          git push origin HEAD

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,51 @@
+name: Update Homebrew formula
+
+# Triggered manually or via repository_dispatch from shell-pool/shpool.
+# To trigger automatically on release, add a workflow step to shell-pool/shpool
+# that calls the GitHub API to dispatch this workflow with the new version tag.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version tag (e.g. v0.9.5)'
+        required: true
+  repository_dispatch:
+    types: [new-release]
+
+jobs:
+  update-formula:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update formula version and SHA256
+        run: |
+          VERSION="${{ github.event.inputs.version || github.event.client_payload.version }}"
+          URL="https://github.com/shell-pool/shpool/archive/refs/tags/${VERSION}.tar.gz"
+          SHA256=$(curl -sL "$URL" | shasum -a 256 | awk '{print $1}')
+
+          sed -i "s|url \".*\"|url \"${URL}\"|" Formula/shpool.rb
+          sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" Formula/shpool.rb
+
+      - name: Open PR
+        run: |
+          VERSION="${{ github.event.inputs.version || github.event.client_payload.version }}"
+          BRANCH="update-formula-${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add Formula/shpool.rb
+          git commit -m "Update formula to ${VERSION}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "Update formula to ${VERSION}" \
+            --body "Automated update of \`Formula/shpool.rb\` for release ${VERSION}." \
+            --base master \
+            --head "$BRANCH"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Resolve version
         id: version

--- a/Formula/shpool.rb
+++ b/Formula/shpool.rb
@@ -1,0 +1,28 @@
+class Shpool < Formula
+  desc "Lightweight persistent shell session manager"
+  homepage "https://github.com/shell-pool/shpool"
+  url "https://github.com/shell-pool/shpool/archive/refs/tags/v0.9.5.tar.gz"
+  sha256 "cc958a1f66ed8c75892544c7921a764f0469233a0ca58b441249ed593bdcdaf0"
+  license "Apache-2.0"
+  head "https://github.com/shell-pool/shpool.git", branch: "master"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install",
+      "--locked",
+      "--root", prefix,
+      "--path", "shpool"
+  end
+
+  service do
+    run [opt_bin/"shpool", "daemon"]
+    keep_alive true
+    log_path var/"log/shpool.log"
+    error_log_path var/"log/shpool.log"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/shpool version")
+  end
+end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# homebrew-shpool
+
+Homebrew tap for [shpool](https://github.com/shell-pool/shpool), a lightweight persistent shell session manager for macOS.
+
+## Installation
+
+```
+brew tap shell-pool/shpool
+brew install shpool
+```
+
+To have the daemon start automatically at login:
+
+```
+brew services start shpool
+```
+
+## SSH configuration
+
+The typical use case is connecting to a Mac running `shpool` from a remote machine. Add a block to `~/.ssh/config` on your client:
+
+```
+Host = main edit
+    Hostname remote.host.example.com
+
+    RemoteCommand /opt/homebrew/bin/shpool attach -f %k
+    RequestTTY yes
+```
+
+Then `ssh main` or `ssh edit` will create or reattach to a named session. `%k` expands to the host alias used on the command line.
+
+> [!NOTE]
+> SSH's `RemoteCommand` runs in a non-login shell that does not source your profile, so `shpool` won't be on `$PATH`. Use the full path to the binary as shown above. Run `which shpool` on the host if it's installed somewhere other than `/opt/homebrew/bin`.
+
+## Configuration
+
+`shpool` can be configured via `~/.config/shpool/config.toml`. See [CONFIG.md](https://github.com/shell-pool/shpool/blob/master/CONFIG.md) in the main repository for the full list of options.
+
+## More information
+
+- [shpool repository](https://github.com/shell-pool/shpool) — source, full documentation, and Linux installation instructions
+- [Wiki](https://github.com/shell-pool/shpool/wiki) — tips, troubleshooting, and advanced usage

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Homebrew tap for [shpool](https://github.com/shell-pool/shpool), a lightweight persistent shell session manager for macOS.
 
+> [!WARNING]
+> Linux is the primary supported platform. macOS support is functional but some features are still being worked on. See the [platform support notes](https://github.com/shell-pool/shpool/blob/master/HACKING.md) in the main repository for the current state.
+
 ## Installation
 
 ```


### PR DESCRIPTION
Initial setup for the `shell-pool/shpool` Homebrew tap. Once merged, `brew tap shell-pool/shpool` will work and users can install without building from source.

### Changes

`Formula/shpool.rb` — the formula itself, targeting the `shpool` workspace member in the Cargo workspace. Has a `service` block so `brew services start shpool` registers the daemon with launchd.

`README.md` — installation instructions, a note about the macOS SSH `$PATH` gotcha, and links back to the main repo for full docs.

`.github/workflows/homebrew.yml` — runs daily, checks the latest release tag against what's in the formula, and commits an update if they differ. Can also be triggered manually with an optional version override. No secrets or cross-repo permissions needed.