### PR TITLE
Fix scheduled Homebrew formula updates

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -20,10 +20,11 @@ jobs:
       - name: Resolve version
         id: version
         run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          REQUESTED_VERSION="${{ github.event.inputs.version }}"
+          if [ "${REQUESTED_VERSION}" != "" ] && [ "${REQUESTED_VERSION}" != "null" ]; then
+            VERSION="${REQUESTED_VERSION}"
           else
-            VERSION=$(curl -s https://api.github.com/repos/shell-pool/shpool/releases/latest | jq -r '.tag_name')
+            VERSION=$(curl -fsSL https://api.github.com/repos/shell-pool/shpool/releases/latest | jq -er '.tag_name')
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
@@ -44,7 +45,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           URL="https://github.com/shell-pool/shpool/archive/refs/tags/${VERSION}.tar.gz"
-          SHA256=$(curl -sL "$URL" | shasum -a 256 | awk '{print $1}')
+          SHA256=$(curl -fsSL "$URL" | shasum -a 256 | awk '{print $1}')
 
           sed -i "s|url \".*\"|url \"${URL}\"|" Formula/shpool.rb
           sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" Formula/shpool.rb

--- a/Formula/shpool.rb
+++ b/Formula/shpool.rb
@@ -1,8 +1,8 @@
 class Shpool < Formula
   desc "Lightweight persistent shell session manager"
   homepage "https://github.com/shell-pool/shpool"
-  url "https://github.com/shell-pool/shpool/archive/refs/tags/null.tar.gz"
-  sha256 "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed"
+  url "https://github.com/shell-pool/shpool/archive/refs/tags/v0.10.0.tar.gz"
+  sha256 "2be86e4671b38d78785e2e59e0e17c3b8df4272bff72731a4f8bf4b09af772a7"
   license "Apache-2.0"
   head "https://github.com/shell-pool/shpool.git", branch: "master"
 


### PR DESCRIPTION
## Summary
- restore the formula to the latest real shpool release, v0.10.0
- treat blank or null workflow_dispatch input as unset so scheduled runs fetch the latest release
- make release metadata and tarball downloads fail fast instead of hashing API/error responses

## Validation
- brew info shell-pool/shpool/shpool
- brew cleanup -n
- ruby -e 'require "psych"; Psych.load_file(".github/workflows/homebrew.yml")'
- verified v0.10.0 tarball SHA256 matches Formula/shpool.rb

Note: brew audit --formula shell-pool/shpool/shpool was attempted locally, but Homebrew hung while bootstrapping developer gems; I terminated it and did not include it as passing validation.